### PR TITLE
Resolved issue with ModifyPlan when the HostIndex is unknown

### DIFF
--- a/qwilt/cdn/cdn_siteconfig_resource.go
+++ b/qwilt/cdn/cdn_siteconfig_resource.go
@@ -341,6 +341,11 @@ func (r *siteConfigResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
+	// If the HostIndex is unknown, we can't do anything
+	if plan.HostIndex.IsUnknown() {
+		return
+	}
+
 	planRawJson := json.RawMessage([]byte(plan.HostIndex.ValueString()))
 	planString, err := json.Marshal(planRawJson)
 	if err != nil {
@@ -356,6 +361,11 @@ func (r *siteConfigResource) ModifyPlan(ctx context.Context, req resource.Modify
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the HostIndex is unknown, we can't do anything
+	if state.HostIndex.IsUnknown() {
 		return
 	}
 


### PR DESCRIPTION
The introduction of a dynamic element, such as a timestamp, to a configuration attribute will make that attribute "unknowable" for certain Terraform calls.  This will typically result in behavior where Terraform is updating the configuration on every apply.

The ModifyPlan method had handling for an empty plan, but not a plan where the host_index might be unknowable.  This resulted in the method treating an unknowable value as an empty string, and recognizing the value as invalid JSON.  The solution is to add handling for an unknowable value.

While this is technically a bug, I can't think of many practical applications for a configuration that changes with every call.  Therefore, I think the fix to this is relatively low priority.  But it is a bug, and this fix should likely be merged when convenient.