### PR TITLE
Playground example corrections

### DIFF
--- a/examples/playground/qwilt-config-basic/main.tf
+++ b/examples/playground/qwilt-config-basic/main.tf
@@ -79,8 +79,8 @@ output "examplecertificate" {
 
 output "examplecertificatetemplate" {
   value = qwilt_cdn_certificate_template.example
+  sensitive = true
 }
-
 
 output "examplesiteactivation" {
   value = qwilt_cdn_site_activation.example

--- a/examples/playground/qwilt-config-multi-workspace/examplesite.tf
+++ b/examples/playground/qwilt-config-multi-workspace/examplesite.tf
@@ -31,6 +31,7 @@ output "examplesiteconfig" {
 
 output "examplecertificate" {
   value = qwilt_cdn_certificate.example
+  sensitive = true
 }
 
 output "examplesiteactivation" {

--- a/examples/playground/qwilt-config-multi-workspace/examplesite2.tf
+++ b/examples/playground/qwilt-config-multi-workspace/examplesite2.tf
@@ -31,6 +31,7 @@ output "examplesiteconfig2" {
 
 output "examplecertificate2" {
   value = qwilt_cdn_certificate.example2
+  sensitive = true
 }
 
 output "examplesiteactivation2" {

--- a/examples/playground/qwilt-config-multi/examplesite.tf
+++ b/examples/playground/qwilt-config-multi/examplesite.tf
@@ -31,6 +31,7 @@ output "examplesiteconfig" {
 
 output "examplecertificate" {
   value = qwilt_cdn_certificate.example
+  sensitive = true
 }
 
 output "examplesiteactivation" {

--- a/examples/playground/qwilt-config-multi/examplesite2.tf
+++ b/examples/playground/qwilt-config-multi/examplesite2.tf
@@ -31,6 +31,7 @@ output "examplesiteconfig2" {
 
 output "examplecertificate2" {
   value = qwilt_cdn_certificate.example2
+  sensitive = true
 }
 
 output "examplesiteactivation2" {

--- a/examples/playground/qwilt-datasource/README.md
+++ b/examples/playground/qwilt-datasource/README.md
@@ -70,6 +70,30 @@ $ terraform plan -var="cert_id=<CertificateID>"
 ```
 The output provides details about the specified cert_id.
 
+## Certificate Template Lookup
+
+The certificate templates data source can be used to query the details of certificate templates for the CSR workflow.  Certificate templates can be queried by common name and template ID.
+
+To search for certificates by common name:
+
+```
+$ terraform plan -var="cert_template_cn=example.com"
+```
+The above command launches a substring match of the common_name attribute for each defined certificate template and outputs the matching certificate_template_ids.
+
+To retrieve a list of all certificate templates, do this:
+
+```
+$ terraform plan -var="cert_template_id=all"
+```
+
+Once you have identified the certificate_template_id that you are targeting, you may search for it directly:
+
+```
+$ terraform plan -var="cert_template_id=<CertificateTemplateID>"
+```
+The output provides details about the specified certificate_template_id.
+
 ## About This Example
 
 This example uses some complex output definitions to query the sites and certs data sources for information.  It illustrates how variables can be defined to search a specific attribute and filter the results.  With some additional effort, the same can be done to query other site, revision, activation, and certificate attributes.

--- a/examples/playground/qwilt-datasource/README.md
+++ b/examples/playground/qwilt-datasource/README.md
@@ -94,6 +94,17 @@ $ terraform plan -var="cert_template_id=<CertificateTemplateID>"
 ```
 The output provides details about the specified certificate_template_id.
 
+## Origin Allow List
+
+The origin allow list data source allows you to view the most current origin IP allow list.  This data can be used, for example, to update the firewall rules of your origin server.
+
+To view the most current origin allow list, do this:
+
+```
+$ terraform plan -var="show_origin_allow_list=true"
+```
+The output provides details about current IPv4 and IPv6 addresses associated with each service provider in Qwilt's network.
+
 ## About This Example
 
-This example uses some complex output definitions to query the sites and certs data sources for information.  It illustrates how variables can be defined to search a specific attribute and filter the results.  With some additional effort, the same can be done to query other site, revision, activation, and certificate attributes.
+This example uses some complex output definitions to query the sites, certs, cert templates, and origin allow list data sources for information.  It illustrates how variables can be defined to search a specific attribute and filter the results.  With some additional effort, the same can be done to query other site, revision, activation, certificate, certificate template, and origin allow list attributes.

--- a/examples/playground/qwilt-datasource/certificate_template_datasource.tf
+++ b/examples/playground/qwilt-datasource/certificate_template_datasource.tf
@@ -1,15 +1,15 @@
-variable "certificate_template_id" {
+variable "cert_template_id" {
   type    = string
   default = null
 }
 
-variable "certificate_template_common_name" {
+variable "cert_template_cn" {
   type    = string
   default = null
 }
 
 data "qwilt_cdn_certificate_templates" "detail" {
   filter = {
-    id = var.certificate_template_id != null && var.certificate_template_id != "all" ? try(tonumber(var.certificate_template_id), -1) : null
+    certificate_template_id = var.cert_template_id != null && var.cert_template_id != "all" ? try(tonumber(var.cert_template_id), -1) : null
   }
 }

--- a/examples/playground/qwilt-datasource/origin_allow_list_datasource.tf
+++ b/examples/playground/qwilt-datasource/origin_allow_list_datasource.tf
@@ -1,2 +1,7 @@
+variable "show_origin_allow_list" {
+  type    = bool
+  default = false
+}
+
 data "qwilt_cdn_origin_allow_list" "detail" {
 }

--- a/examples/playground/qwilt-datasource/outputs-certificate_templates.tf
+++ b/examples/playground/qwilt-datasource/outputs-certificate_templates.tf
@@ -1,19 +1,19 @@
-# Output a cert list if cert_id is "all" and cert_domain isn't defined.
+# Output a cert template list if cert_template_id is "all" and cert_template_cn isn't defined.
 output "certificate_templates_list" {
-  value = var.certificate_template_id == "all" && var.certificate_template_common_name == null ? [for certificate_template in data.qwilt_cdn_certificate_templates.detail.certificate_template : { common_name = certificate_template.domain, id = certificate_template.cert_id }] : null
+  value = var.cert_template_id == "all" && var.cert_template_cn == null ? [for certificate_template in data.qwilt_cdn_certificate_templates.detail.certificate_template : { common_name = certificate_template.common_name, certificate_template_id = certificate_template.certificate_template_id }] : null
 }
 
-# Output a matching cert list if cert_domain is defined
+# Output a matching cert template list if cert_template_cn is defined
 output "certificate_templates_list_by_common_name" {
-  value = var.certificate_template_common_name != null ? [for certificate_template in data.qwilt_cdn_certificate_templates.detail.certificate_template : { common_name = certificate_template.common_name, id = certificate_template.certificate_template_id } if strcontains(certificate_template.common_name, var.certificate_template_common_name)] : null
+  value = var.cert_template_cn != null ? [for certificate_template in data.qwilt_cdn_certificate_templates.detail.certificate_template : { common_name = certificate_template.common_name, certificate_template_id = certificate_template.certificate_template_id } if strcontains(certificate_template.common_name, var.cert_template_cn)] : null
 }
 
-# Output the details of a matching cert if cert_id is set to an explicit value.
+# Output the details of a matching cert template if cert_template_id is set to an explicit value.
 output "certificate_template_detail" {
-  value = var.certificate_template_id == "all" || var.certificate_template_id == null || data.qwilt_cdn_certificate_templates.detail.certificate_template == null ? null : data.qwilt_cdn_certificate_templates.detail.certificate_template[0]
+  value = var.cert_template_id == "all" || var.cert_template_id == null || data.qwilt_cdn_certificate_templates.detail.certificate_template == null ? null : data.qwilt_cdn_certificate_templates.detail.certificate_template[0]
 }
 
-# Output to dump every attribute of every certificate available to users in your org.
+# Output to dump every attribute of every cert template available to users in your org.
 #output "all_certificate_templates" {
 #    value = data.qwilt_cdn_certificate_templates.detail
 #}

--- a/examples/playground/qwilt-datasource/outputs-origin-allow-list.tf
+++ b/examples/playground/qwilt-datasource/outputs-origin-allow-list.tf
@@ -1,5 +1,9 @@
-
-# Output to dump every attribute of every certificate available to users in your org.
-output "all_origin_allow_list" {
-  value = data.qwilt_cdn_origin_allow_list.detail
+# Conditionally show the complete origin allow list.
+output "origin_allow_list" {
+  value = var.show_origin_allow_list == false ? null : data.qwilt_cdn_origin_allow_list.detail
 }
+
+# Unconditionally output the complete origin allow list.
+#output "all_origin_allow_list" {
+#  value = data.qwilt_cdn_origin_allow_list.detail
+#}

--- a/examples/playground/qwilt-import/main.tf
+++ b/examples/playground/qwilt-import/main.tf
@@ -43,6 +43,7 @@ output "examplesiteconfig" {
 
 output "examplecertificate" {
   value = qwilt_cdn_certificate.example
+  sensitive = true
 }
 
 output "examplesiteactivation" {


### PR DESCRIPTION
This commit corrects two problems introduced to the qwilt-datasource playground example:
1.  Corrects the certificate template data source so that templates can be queried by common name and ID.
2.  Adds a switch around origin allow data source so that it only outputs whenever the user requests it.

Additionally, minor fixes were applied to silence warnings around sensitive data for certificates.